### PR TITLE
now, it can run on tf v0.12.1

### DIFF
--- a/udc_hparams.py
+++ b/udc_hparams.py
@@ -19,8 +19,8 @@ tf.flags.DEFINE_string("vocab_path", None, "Path to vocabulary.txt file")
 
 # Training Parameters
 tf.flags.DEFINE_float("learning_rate", 0.001, "Learning rate")
-tf.flags.DEFINE_integer("batch_size", 128, "Batch size during training")
-tf.flags.DEFINE_integer("eval_batch_size", 16, "Batch size during evaluation")
+tf.flags.DEFINE_integer("batch_size", 64, "Batch size during training")
+tf.flags.DEFINE_integer("eval_batch_size", 8, "Batch size during evaluation")
 tf.flags.DEFINE_string("optimizer", "Adam", "Optimizer Name (Adam, Adagrad, etc)")
 
 FLAGS = tf.flags.FLAGS

--- a/udc_model.py
+++ b/udc_model.py
@@ -26,7 +26,8 @@ def create_model_fn(hparams, model_impl):
     utterance, utterance_len = get_id_feature(
         features, "utterance", "utterance_len", hparams.max_utterance_len)
 
-    batch_size = targets.get_shape().as_list()[0]
+    if mode == tf.contrib.learn.ModeKeys.EVAL:
+        batch_size = targets.get_shape().as_list()[0]
 
     if mode == tf.contrib.learn.ModeKeys.TRAIN:
       probs, loss = model_impl(

--- a/udc_predict.py
+++ b/udc_predict.py
@@ -55,4 +55,5 @@ if __name__ == "__main__":
   print("Context: {}".format(INPUT_CONTEXT))
   for r in POTENTIAL_RESPONSES:
     prob = estimator.predict(input_fn=lambda: get_features(INPUT_CONTEXT, r))
-    print("{}: {:g}".format(r, prob[0,0]))
+    prob = next(prob)
+    print("{}: {:g}".format(r, prob[0]))

--- a/udc_test.py
+++ b/udc_test.py
@@ -12,7 +12,7 @@ from models.dual_encoder import dual_encoder_model
 tf.flags.DEFINE_string("test_file", "./data/test.tfrecords", "Path of test data in TFRecords format")
 tf.flags.DEFINE_string("model_dir", None, "Directory to load model checkpoints from")
 tf.flags.DEFINE_integer("loglevel", 20, "Tensorflow log level")
-tf.flags.DEFINE_integer("test_batch_size", 16, "Batch size for testing")
+tf.flags.DEFINE_integer("test_batch_size", 8, "Batch size for testing")
 FLAGS = tf.flags.FLAGS
 
 if not FLAGS.model_dir:


### PR DESCRIPTION
- batch size changed.
- change iterator to list on predict.

버전 문제인지 제 환경(python v3.5, tf v0.12.0 gpu)에선 아예 동작하지 않아서 동작하게 수정해봤습니다. deprecated 경고 2개(Saver version, num_queue_runners)는 contrib 패키지 내부 코드 내용으로 tf 업그레이드로 자동 해결 되리라 보입니다.